### PR TITLE
[Fix] 댓글input 입력시 comments재랜더링 되는 문제 해결 close #166

### DIFF
--- a/client/src/components/Comments/Comments.tsx
+++ b/client/src/components/Comments/Comments.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import instance from 'utils/functions/axios';
 import DeleteModal from 'components/Modal/DeleteModal';
 import { CommentData } from 'utils/functions/type';
@@ -21,6 +21,7 @@ function Comments({comment, commentsUserList, setReRender}: GreetingProps) {
 	const [openCmmtDelModal, setOpenCmmtDelModal] = useState<boolean>(false);
 	const [modifyState, setModifyState] = useState<boolean>(false);
 	const [modifyCmmt, setModifyCmmt] = useState<string>(content);
+
 
 	const clickCmmtDelModalHandler = () => {
 		setOpenCmmtDelModal(!openCmmtDelModal);
@@ -120,4 +121,4 @@ function Comments({comment, commentsUserList, setReRender}: GreetingProps) {
 	);
 }
 
-export default Comments
+export default React.memo(Comments)

--- a/client/src/pages/Detail/Detail.tsx
+++ b/client/src/pages/Detail/Detail.tsx
@@ -58,6 +58,7 @@ function Detail() {
 		.then((res) => {
 			setDetailData(res.data);
       setCommentData(res.data.comment)
+      setCommentsUserList(Array.from(new Set(res.data.comment.filter((el:CommentData) => !el.isAuthor).map((el:CommentData) => el.authorId))))
 		})
 		.catch((err) => console.log(err));
 	},[boxState, reRender])
@@ -73,11 +74,12 @@ function Detail() {
 	const { id, title, content, commentCnt, viewCnt, likeCnt, isUsers, isNotice, blameCnt, createdDate, modifiedDate } = detailData.post
   const [commentData, setCommentData] = useState([])
 	const shortDate = createdDate?.slice(0, 16).replace('T', ' ');
-	const commentsUserList = Array.from(new Set(commentData.filter((el:CommentData) => !el.isAuthor).map((el:CommentData) => el.authorId)));
+  const [commentsUserList, setCommentsUserList] = useState([-1])
+
 
 	const inputCmmtHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
 		setComment(e.target.value);
-	}
+  }
 
 	const clickPostDelModalHandler = () => {
 		setOpenPostDelModal(!openPostDelModal);


### PR DESCRIPTION
<!--
  PR 작성 가이드
1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
2. emoji, @어노테이션 등을 사용하여 효과적으로 소통할 것.
3. 명확하게 질문하고 명확하게 답변할 것.
4. 새로운 모듈 설치시 PR message에 기재할 것.
5. PR 올리기전에 branch 반드시 확인할 것. 
-->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
- 인풋에 글자 입력시 commnets 컴포넌트가 계속해서 재렌더링 되는 이슈가 있어 최적화 하였습니다.
-  comments 컴포넌트 최적화


- 댓글입력시 detail컴포넌트 전체가 재랜더링되는 이슈가 있습니다. input을 커스텀훅으로 관리해야할 것 같습니다.

